### PR TITLE
Add a test that loads the module

### DIFF
--- a/Meta
+++ b/Meta
@@ -24,7 +24,7 @@ devel:
 requires:
   # Commented out because we want to use (but not support) on 5.6:
   # perl: 5.8.1
-  Test::Base: 0.86
+  Test::Base: 0.89
 
 =zild:
   test-000: none

--- a/test/load.t
+++ b/test/load.t
@@ -1,0 +1,3 @@
+use Test::More tests => 1;
+
+use_ok('Test::YAML');


### PR DESCRIPTION
Currently there are no tests at all, newer cpan clients will interpret this
as failed.

See #3

http://matrix.cpantesters.org/?dist=Test-YAML+1.06

